### PR TITLE
refactor: alpine image + sleep-loop scheduler (drop cron, ~200MB→~100MB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,28 @@
 # 第一階段：構建環境
-FROM python:3.11-slim AS builder
+FROM python:3.11-alpine AS builder
 
-# 設定工作目錄
 WORKDIR /app
 
-# 安裝構建依賴
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        build-essential \
-    && rm -rf /var/lib/apt/lists/*
+# 編譯型相依套件可能需要的建構工具（僅存在於 builder 階段，不進入最終 image）
+RUN apk add --no-cache build-base
 
 # 複製專案檔案
 COPY pyproject.toml README.md ./
 COPY src/ ./src/
 
-# 安裝 Python 依賴
-RUN pip install --no-cache-dir pip setuptools wheel && \
-    pip install --no-cache-dir -e . && \
-    pip install --no-cache-dir telnetlib3
+# 將套件與相依安裝到獨立 prefix，方便整包複製到最終 image
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir --prefix=/install . \
+    && pip install --no-cache-dir --prefix=/install telnetlib3
 
 # 第二階段：執行環境
-FROM python:3.11-slim
+FROM python:3.11-alpine
+
+# OCI image labels — surfaced on Docker Hub.
+LABEL org.opencontainers.image.title="PTTAutoSign" \
+      org.opencontainers.image.description="Automatically sign in to PTT BBS daily and report via Telegram." \
+      org.opencontainers.image.source="https://github.com/crazycat836/PTTAutoSign" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 # 需要使用者提供的環境變數 (默認為空，運行時必須提供)
 ENV PTT_USERNAME="" \
@@ -30,46 +32,33 @@ ENV PTT_USERNAME="" \
 
 # 設定時區
 ENV TZ=Asia/Taipei
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 執行時必要的系統依賴：
+#   - bash：docker_runner.sh 使用 bash 專屬語法（alpine 預設只有 ash）
+#   - tzdata：提供 /usr/share/zoneinfo 以套用 Asia/Taipei
+#   - ca-certificates：HTTPS（Telegram / PTT）TLS 驗證
+# 排程改由腳本內建 sleep loop 處理，不再安裝 cron。
+RUN apk add --no-cache bash tzdata ca-certificates \
+    && cp /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo "$TZ" > /etc/timezone \
+    && mkdir -p /app/data
 
 # 設定工作目錄
 WORKDIR /app
 
-# 安裝運行時必要的系統依賴
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        cron \
-        procps \
-        rsyslog \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /etc/rsyslog.d /app/data /var/log \
-    && if [ -f /etc/rsyslog.d/50-default.conf ]; then \
-        sed -i 's/^\s*#\?\s*cron\.\*.*$/cron.* \/var\/log\/cron.log/' /etc/rsyslog.d/50-default.conf; \
-    else \
-        echo 'cron.* /var/log/cron.log' > /etc/rsyslog.d/cron.conf; \
-    fi
+# 從建構環境複製已安裝的 Python 套件（含 pttautosign 與相依）
+COPY --from=builder /install /usr/local
 
-# 從建構環境複製 Python 套件和應用程式程式碼
-COPY --from=builder /usr/local/lib/python3.11/site-packages/ /usr/local/lib/python3.11/site-packages/
-COPY --from=builder /app/src/ /app/src/
-
-# 複製腳本並設定執行權限
+# 複製腳本並設定執行權限（root-only 0700，避免他人讀取/執行）
 COPY scripts/ ./scripts/
-RUN chmod +x /app/scripts/*.sh
+RUN chmod 0700 /app/scripts/*.sh
 
 # 設定環境變數
-ENV PYTHONPATH=/app \
-    CRON_DATA_DIR=/app/data \
-    PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONDONTWRITEBYTECODE=1
 
 # 清理不必要的檔案
-RUN find /app -name "__pycache__" -type d -exec rm -rf {} +  2>/dev/null || true && \
-    find /app -name "*.pyc" -delete && \
-    find /app -name "*.pyo" -delete && \
-    find /app -name "*.pyd" -delete
-
-# 暴露健康檢查端口
-EXPOSE 8000
+RUN find /app -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true \
+    && find /app -name "*.pyc" -delete
 
 # 設定入口點
-ENTRYPOINT ["/app/scripts/docker_runner.sh"] 
+ENTRYPOINT ["/app/scripts/docker_runner.sh"]

--- a/README.md
+++ b/README.md
@@ -242,7 +242,10 @@ poetry run pytest --cov=pttautosign --cov-report=term-missing
    python -m pttautosign.main --test-login
    
    # Test with Docker
-   docker build -t pttautosign-dev .
+   # Build for the host that will RUN the container. On Apple Silicon (arm64),
+   # add --platform so the image matches an amd64/x86_64 host (e.g. most NAS/VPS),
+   # otherwise the container fails at start with "exec format error".
+   docker build --platform linux/amd64 -t pttautosign-dev .
    docker run --rm -e TEST_MODE=true pttautosign-dev
    ```
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -245,7 +245,10 @@ poetry run flake8 src/
    python -m pttautosign.main --test-login
    
    # 使用 Docker 測試
-   docker build -t pttautosign-dev .
+   # 請依「實際執行容器的主機」架構來 build。在 Apple Silicon (arm64) 上
+   # 要加 --platform，讓 image 對應 amd64/x86_64 主機（多數 NAS / VPS），
+   # 否則容器啟動時會出現 "exec format error"。
+   docker build --platform linux/amd64 -t pttautosign-dev .
    docker run --rm -e TEST_MODE=true pttautosign-dev
    ```
 

--- a/scripts/docker_runner.sh
+++ b/scripts/docker_runner.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 # PTT Auto Sign Docker Runner Script
-# 
-# 說明：PTT 自動簽到的 Docker 環境配置與運行腳本
-# 功能：
-#   - 測試模式：每分鐘執行一次，共執行 3 次
-#   - 生產模式：每天在隨機時間執行一次，可設定為固定或每日變動
-
+#
+# 說明：PTT 自動簽到的容器進入點與排程器。
+# 設計：不依賴系統 cron，改用單一程序的 sleep loop 自我排程，
+#       因此可在 alpine（無 Debian cron）等精簡基底上運行，
+#       且所有輸出天然落在 PID1 的 stdout/stderr，`docker logs` 直接可見。
+#
+# 模式：
+#   - 測試模式 (TEST_MODE=true)：每分鐘執行一次，共 3 次後結束容器。
+#   - 生產模式 + 每日隨機時間 (RANDOM_DAILY_TIME=true)：每天於 9-17 點的
+#     隨機時間執行一次，並在每次排程更新時發送 Telegram 通知。
+#   - 生產模式 + 固定時間 (RANDOM_DAILY_TIME=false)：啟動時抽一次隨機時間，
+#     之後每天於該固定時間執行。
 
 # 初始化環境變數（使用默認值，若未設置）
-export EXECUTION_COUNT=${EXECUTION_COUNT:-0}
 export TEST_MODE=${TEST_MODE:-false}
 export DEBUG_MODE=${DEBUG_MODE:-false}
 export RANDOM_DAILY_TIME=${RANDOM_DAILY_TIME:-true}  # 控制是否每天使用不同的隨機時間
@@ -26,23 +31,30 @@ export FORCE_COLOR=1              # 強制啟用顏色輸出
 export PYTHONCOLORIZE=1           # 啟用彩色輸出
 export TERM=xterm-256color        # 終端類型
 
+# 簽到工作時段（臺灣時間），用具名常數取代魔術數字。
+readonly WORK_HOUR_START=9        # 最早 9 點
+readonly WORK_HOUR_SPAN=9         # 9..17（9 + 0..8）
+readonly TEST_RUNS=3             # 測試模式執行次數
+readonly TEST_INTERVAL=60        # 測試模式每次間隔（秒）
+readonly SECONDS_PER_DAY=86400
+
 # =============================================================================
 # 日誌輸出函數
 # =============================================================================
 
 # 標準日誌輸出
 log_message() {
-    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
-    local message="[${timestamp}] $1"
-    echo "$message"
+    local timestamp
+    timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[${timestamp}] $1"
 }
 
 # 調試日誌輸出（僅在 DEBUG_MODE=true 時顯示）
 log_debug() {
     if [ "$DEBUG_MODE" = "true" ]; then
-        local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
-        local message="[DEBUG] [${timestamp}] $1"
-        echo "$message"
+        local timestamp
+        timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+        echo "[DEBUG] [${timestamp}] $1"
     fi
 }
 
@@ -74,18 +86,18 @@ check_environment() {
 # 執行 PTT 登入和通知
 run_ptt_login() {
     local send_notification=${1:-true}
-    
+
     log_debug "開始執行 PTT 登入..."
-    
-    cd /app
-    
+
+    cd /app || return 1
+
     # 查找 Python 路徑
-    PYTHON_PATH=$(which python || which python3)
+    PYTHON_PATH=$(command -v python || command -v python3)
     if [ -z "$PYTHON_PATH" ]; then
         log_message "錯誤: 找不到 Python 可執行檔，無法執行 PTT 登入"
         return 1
     fi
-    
+
     # 設置通知功能
     if [ "$send_notification" = "false" ]; then
         log_debug "已暫時停用通知功能（用於測試）"
@@ -94,15 +106,15 @@ run_ptt_login() {
         log_debug "已啟用通知功能"
         unset DISABLE_NOTIFICATIONS
     fi
-    
+
     # 執行 PTT 自動簽到程式
     local output
     local status
-    
+
     log_debug "執行命令: $PYTHON_PATH -m pttautosign.main --test-login"
     output=$($PYTHON_PATH -m pttautosign.main --test-login 2>&1)
     status=$?
-    
+
     # 顯示程式輸出
     if [ "$DEBUG_MODE" = "true" ]; then
         log_debug "PTT 程式完整輸出:"
@@ -110,27 +122,15 @@ run_ptt_login() {
     else
         log_message "PTT 程式執行完成，狀態碼: $status"
     fi
-    
+
     # 提取登入統計
     successful_logins=$(echo "$output" | grep -o "登入成功：[0-9]*" | grep -o "[0-9]*" || echo "0")
     failed_logins=$(echo "$output" | grep -o "登入失敗：[0-9]*" | grep -o "[0-9]*" || echo "0")
     total_accounts=$((successful_logins + failed_logins))
-    
+
     # 顯示結果摘要
     log_message "登入測試完成: 總共 $total_accounts 個帳號, 成功 $successful_logins, 失敗 $failed_logins"
-    
-    # 增加執行計數並顯示
-    EXECUTION_COUNT=$((EXECUTION_COUNT + 1))
-    log_message "已完成第 $EXECUTION_COUNT 次 PTT 登入任務"
-    
-    # 測試模式特殊處理：檢查是否達到執行次數上限
-    if [ "$TEST_MODE" = "true" ] && [ $EXECUTION_COUNT -ge 3 ]; then
-        log_message "✅ 已完成所有 3 次測試模式執行！正在停止 cron 任務..."
-        rm -f /etc/cron.d/ptt-auto-sign
-        service cron reload >/dev/null 2>&1 || true
-        log_message "已成功停止 cron 任務，測試完成"
-    fi
-    
+
     # 回傳結果
     if [ $status -eq 0 ]; then
         log_message "PTT 自動簽到任務執行成功"
@@ -144,13 +144,13 @@ run_ptt_login() {
 # 驗證 PTT 憑證
 verify_credentials() {
     log_message "正在驗證 PTT 憑證..."
-    
+
     # 禁用通知 - 只測試登入
     run_ptt_login false
-    
+
     # 獲取結果狀態
     local status=$?
-    
+
     if [ $status -eq 0 ]; then
         log_message "✅ 驗證成功！PTT 登入憑證有效"
         return 0
@@ -160,261 +160,146 @@ verify_credentials() {
     fi
 }
 
-# 產生隨機執行時間
+# =============================================================================
+# 排程器（取代 cron）
+# =============================================================================
+
+# 產生隨機執行時間，結果寫入 RANDOM_HOUR / RANDOM_MINUTE。
 generate_random_time() {
     RANDOM_MINUTE=$((RANDOM % 60))
-    RANDOM_HOUR=$((RANDOM % 9 + 9))  # 9-17 (9 AM to 5 PM)
-    log_message "已產生新的隨機執行時間：每天 $RANDOM_HOUR:$RANDOM_MINUTE (臺灣時間)"
-    return 0
+    RANDOM_HOUR=$((RANDOM % WORK_HOUR_SPAN + WORK_HOUR_START))  # 9-17 (9 AM to 5 PM)
+    log_message "已產生新的隨機執行時間：每天 ${RANDOM_HOUR}:$(printf '%02d' "$RANDOM_MINUTE") (臺灣時間)"
 }
 
-# 更新 cron 任務時間
-update_cron_time() {
-    log_debug "更新 cron 任務排程時間..."
-    
-    # 產生新的隨機時間
-    generate_random_time
-    
-    # 更新 cron 任務設定檔
-    cat > /etc/cron.d/ptt-auto-sign << EOL
-# PTT Auto Sign production crontab
-# 執行時間: $RANDOM_HOUR:$RANDOM_MINUTE (Taiwan time)
-$RANDOM_MINUTE $RANDOM_HOUR * * * root /app/scripts/cron_wrapper.sh
+# 計算距離下一個 HH:MM 的秒數。
+#   $1 = 目標小時, $2 = 目標分鐘, $3 = force_tomorrow(0/1)
+# 只用 date +%H/%M/%S（busybox 也支援），避免依賴 GNU date -d 解析。
+# Asia/Taipei 無日光節約，因此每日固定 86400 秒。
+seconds_until() {
+    local target_hour=$1 target_minute=$2 force_tomorrow=${3:-0}
+    local now_h now_m now_s now_sod target_sod delay
 
-# 每天午夜更新執行時間 (如果啟用了隨機每日時間)
-0 0 * * * root [ "$RANDOM_DAILY_TIME" = "true" ] && /app/scripts/daily_time_updater.sh
+    now_h=$(date +%H); now_m=$(date +%M); now_s=$(date +%S)
+    # 10# 前綴避免 08/09 被當成八進位。
+    now_sod=$((10#$now_h * 3600 + 10#$now_m * 60 + 10#$now_s))
+    target_sod=$((target_hour * 3600 + target_minute * 60))
 
-# Empty line required for cron.d files
-EOL
-    chmod 0644 /etc/cron.d/ptt-auto-sign
-    
-    # 創建每日更新時間的腳本，使用 telegram.py 發送通知
-    cat > /app/scripts/daily_time_updater.sh << EOL
-#!/bin/bash
-# 每日更新 cron 任務時間的腳本
-# 功能：自動產生新的隨機執行時間並發送通知
+    delay=$((target_sod - now_sod))
+    # 已過今天的目標時間，或要求排到明天 → 加一天。
+    if [ "$force_tomorrow" = "1" ] || [ $delay -le 0 ]; then
+        delay=$((delay + SECONDS_PER_DAY))
+    fi
+    echo "$delay"
+}
 
-# 產生新的隨機時間
-RANDOM_MINUTE=\$((RANDOM % 60))
-RANDOM_HOUR=\$((RANDOM % 9 + 9))  # 9-17 (9 AM to 5 PM)
+# 排程更新時透過 Telegram 通知下次簽到時間（沿用既有 TelegramBot 模組）。
+notify_schedule_update() {
+    local hour=$1 minute=$2
 
-# 更新 cron 設定檔
-sed -i "s/^[0-9]\\+ [0-9]\\+ \\* \\* \\* root \\/app\\/scripts\\/cron_wrapper.sh/\$RANDOM_MINUTE \$RANDOM_HOUR \\* \\* \\* root \\/app\\/scripts\\/cron_wrapper.sh/" /etc/cron.d/ptt-auto-sign
+    [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ] || return 0
 
-# 重新載入 cron 設定
-service cron reload >/dev/null 2>&1 || true
+    export NEW_HOUR="$hour"
+    export NEW_MINUTE="$(printf '%02d' "$minute")"
+    export NEW_TIMESTAMP="$(date '+%Y-%m-%d %H:%M:%S')"
 
-# 記錄變更
-TIMESTAMP=\$(date '+%Y-%m-%d %H:%M:%S')
-echo "[\$TIMESTAMP] 已更新 PTT 自動簽到時間為 \$RANDOM_HOUR:\$RANDOM_MINUTE (臺灣時間)"
-
-# 使用 Python 調用 telegram.py 發送通知
-if [ ! -z "\$TELEGRAM_BOT_TOKEN" ] && [ ! -z "\$TELEGRAM_CHAT_ID" ]; then
-    # 建立 Python 腳本
-    cat > /tmp/telegram_notify.py << PYTHON
-#!/usr/bin/env python3
-from pttautosign.utils.telegram import TelegramBot
-from pttautosign.utils.config import TelegramConfig
+    cd /app && python - <<'PYTHON'
+import os
 import sys
-import datetime
 
-# 時間資訊
-hour = "\$RANDOM_HOUR"
-minute = "\$RANDOM_MINUTE"
-timestamp = "\$TIMESTAMP"
+from pttautosign.utils.config import TelegramConfig
+from pttautosign.utils.telegram import TelegramBot
 
-# 產生日期標籤 (如 #20250422 格式)
-date_tag = timestamp.split()[0].replace('-', '')
+token = os.environ["TELEGRAM_BOT_TOKEN"]
+chat_id = os.environ["TELEGRAM_CHAT_ID"]
+hour = os.environ.get("NEW_HOUR", "")
+minute = os.environ.get("NEW_MINUTE", "")
+timestamp = os.environ.get("NEW_TIMESTAMP", "")
+date_tag = timestamp.split()[0].replace("-", "") if timestamp else ""
 
-# 準備通知訊息 (使用中文格式)
-message = f"✅ PTT 自動簽到時間已更新\\n\\n📅 下次簽到時間：{hour}:{minute} (臺灣時間)\\n🕒 更新於：{timestamp}\\n#ptt #{date_tag}"
-
-# 建立 Telegram 配置
-config = TelegramConfig(
-    token="\$TELEGRAM_BOT_TOKEN",
-    chat_id="\$TELEGRAM_CHAT_ID"
+message = (
+    "✅ PTT 自動簽到時間已更新\n\n"
+    f"📅 下次簽到時間：{hour}:{minute} (臺灣時間)\n"
+    f"🕒 更新於：{timestamp}\n"
+    f"#ptt #{date_tag}"
 )
 
-# 建立 Telegram 機器人並發送訊息
+config = TelegramConfig(token=token, chat_id=chat_id)
 bot = TelegramBot(config)
-success = bot.send_message(message)
-
-# 回報結果
-if success:
-    print("[\$TIMESTAMP] Telegram 通知已成功發送")
-    sys.exit(0)
-else:
-    print("[\$TIMESTAMP] Telegram 通知發送失敗")
-    sys.exit(1)
+sys.exit(0 if bot.send_message(message) else 1)
 PYTHON
+    local result=$?
+    unset NEW_HOUR NEW_MINUTE NEW_TIMESTAMP
 
-    # 執行 Python 腳本
-    cd /app && PYTHONPATH=/app python /tmp/telegram_notify.py
-    RESULT=\$?
-    
-    # 清理臨時腳本
-    rm -f /tmp/telegram_notify.py
-    
-    # 如果發送失敗，嘗試使用備用方法 (curl)
-    if [ \$RESULT -ne 0 ]; then
-        echo "[\$TIMESTAMP] 嘗試使用備用方法發送通知..."
-        
-        # 準備通知訊息 (使用中文格式)
-        DATE_TAG=\$(echo \$TIMESTAMP | cut -d' ' -f1 | tr -d '-')
-        MESSAGE="✅ PTT 自動簽到時間已更新\\n\\n📅 下次簽到時間：\$RANDOM_HOUR:\$RANDOM_MINUTE (臺灣時間)\\n🕒 更新於：\$TIMESTAMP\\n#ptt #\$DATE_TAG"
-        
-        # 發送到 Telegram
-        curl -s -X POST "https://api.telegram.org/bot\$TELEGRAM_BOT_TOKEN/sendMessage" \
-            -d chat_id="\$TELEGRAM_CHAT_ID" \
-            -d text="\$MESSAGE" \
-            -d parse_mode="HTML" \
-            -d disable_notification=false >/dev/null
-        
-        if [ \$? -eq 0 ]; then
-            echo "[\$TIMESTAMP] Telegram 通知已通過備用方法成功發送"
-        else
-            echo "[\$TIMESTAMP] 所有通知方法均失敗"
-        fi
+    if [ $result -ne 0 ]; then
+        log_message "⚠️ 排程更新通知發送失敗（不影響簽到排程）"
     fi
-fi
-EOL
-    chmod +x /app/scripts/daily_time_updater.sh
-    
-    log_debug "cron 任務排程時間已成功更新"
     return 0
 }
 
-# 設置 cron 任務
-setup_cron_job() {
-    log_message "正在設置自動執行排程..."
-    
-    # 檢查是否在 Docker 容器內
-    if [ ! -f "/.dockerenv" ] && [ ! -d "/app" ]; then
-        log_message "警告: 不在 Docker 容器內，跳過 cron 設置"
-        return 0
-    fi
-    
-    # 查找 Python 可執行檔的完整路徑
-    PYTHON_PATH=$(which python)
-    if [ -z "$PYTHON_PATH" ]; then
-        PYTHON_PATH=$(which python3)
-    fi
-    
-    if [ -z "$PYTHON_PATH" ]; then
-        log_message "錯誤: 找不到 Python 可執行檔，無法設置 cron 任務"
-        return 1
-    fi
-    
-    log_debug "Python 路徑: $PYTHON_PATH"
-    
-    # 創建 cron 的 wrapper 腳本來管理執行計數
-    cat > /app/scripts/cron_wrapper.sh << EOL
-#!/bin/bash
-# cron 任務包裝腳本
-# 功能：管理執行次數，傳遞環境變數，記錄執行時間
-
-# 讀取當前執行計數或初始化為0
-EXECUTION_COUNT=\${EXECUTION_COUNT:-0}
-
-# 執行主腳本
-cd /app && echo "=== Cron 任務開始執行於 \$(date) ==="
-PYTHONPATH=/app TEST_MODE=$TEST_MODE DEBUG_MODE=$DEBUG_MODE PTT_USERNAME=$PTT_USERNAME PTT_PASSWORD=$PTT_PASSWORD TELEGRAM_BOT_TOKEN=$TELEGRAM_BOT_TOKEN TELEGRAM_CHAT_ID=$TELEGRAM_CHAT_ID EXECUTION_COUNT=\$EXECUTION_COUNT PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /app/scripts/docker_runner.sh --run-ptt-login
-RESULT=\$?
-
-# 增加執行計數
-EXECUTION_COUNT=\$((EXECUTION_COUNT + 1))
-
-# 寫入更新後的執行計數到下一次的 cron 環境
-if [ "$TEST_MODE" = "true" ] && [ \$EXECUTION_COUNT -lt 3 ]; then
-    # 更新 cron 環境變數
-    sed -i "s/EXECUTION_COUNT=[0-9]*/EXECUTION_COUNT=\$EXECUTION_COUNT/" /etc/cron.d/ptt-auto-sign
-fi
-
-echo "=== Cron 任務執行完成於 \$(date) ==="
-exit \$RESULT
-EOL
-    chmod +x /app/scripts/cron_wrapper.sh
-    
-    if [ "$TEST_MODE" = "true" ]; then
-        # 測試模式：每分鐘執行一次，共3次
-        log_message "設置測試模式排程：每分鐘執行一次，共3次"
-        
-        # 創建 crontab 文件
-        cat > /etc/cron.d/ptt-auto-sign << EOL
-# PTT 自動簽到測試模式 (每分鐘執行一次，共3次)
-* * * * * root EXECUTION_COUNT=$EXECUTION_COUNT /app/scripts/cron_wrapper.sh
-
-# 空行是必須的
-EOL
-        chmod 0644 /etc/cron.d/ptt-auto-sign
-        
-        log_message "測試模式排程已設置完成"
-    else
-        # 生產模式：每天隨機時間執行，並根據設定決定是否每天更新時間
-        if [ "$RANDOM_DAILY_TIME" = "true" ]; then
-            log_message "設置生產模式排程 (每天隨機時間，自動更新)"
-            update_cron_time
-        else
-            # 固定隨機時間模式
-            RANDOM_MINUTE=$((RANDOM % 60))
-            RANDOM_HOUR=$((RANDOM % 9 + 9))  # 9-17 (9 AM to 5 PM)
-            
-            log_message "設置生產模式排程：固定在每天 $RANDOM_HOUR:$RANDOM_MINUTE 執行（臺灣時間）"
-            
-            # 創建 crontab 文件
-            cat > /etc/cron.d/ptt-auto-sign << EOL
-# PTT 自動簽到生產模式 (每天固定時間執行)
-# 執行時間: $RANDOM_HOUR:$RANDOM_MINUTE (Taiwan time)
-$RANDOM_MINUTE $RANDOM_HOUR * * * root /app/scripts/cron_wrapper.sh
-
-# 空行是必須的
-EOL
-            chmod 0644 /etc/cron.d/ptt-auto-sign
-            
-            log_message "生產模式排程已設置完成，執行時間固定"
-        fi
-    fi
-    
-    # 啟動 cron 服務
-    log_debug "重新啟動 cron 服務..."
-    service cron restart >/dev/null 2>&1 || true
-    
-    # 檢查 cron 服務狀態
-    if service cron status >/dev/null 2>&1; then
-        log_message "✅ cron 服務已成功啟動"
-        return 0
-    else
-        log_message "❌ cron 服務啟動失敗"
-        return 1
-    fi
+# 睡到指定秒數後再執行；秒數為 0 時直接返回。
+sleep_seconds() {
+    local seconds=$1
+    [ "$seconds" -gt 0 ] && sleep "$seconds"
 }
 
-# 監控容器運行
-monitor_container() {
-    log_message "容器已成功啟動並進入監控模式"
-    
-    # 顯示運行模式資訊
+# 測試模式：每分鐘執行一次，共 TEST_RUNS 次後結束。
+run_test_schedule() {
+    log_message "測試模式：每分鐘執行一次，共 ${TEST_RUNS} 次"
+    local i=1
+    while [ $i -le $TEST_RUNS ]; do
+        log_message "測試執行第 ${i} / ${TEST_RUNS} 次"
+        run_ptt_login true
+        [ $i -lt $TEST_RUNS ] && sleep "$TEST_INTERVAL"
+        i=$((i + 1))
+    done
+    log_message "✅ 已完成 ${TEST_RUNS} 次測試執行，容器即將結束"
+}
+
+# 生產模式：固定時間，每天於同一隨機時間執行。
+run_fixed_schedule() {
+    generate_random_time
+    local fixed_hour=$RANDOM_HOUR fixed_minute=$RANDOM_MINUTE
+    log_message "生產模式（固定時間）：每天 ${fixed_hour}:$(printf '%02d' "$fixed_minute") 執行（臺灣時間）"
+
+    local first=1 delay
+    while true; do
+        delay=$(seconds_until "$fixed_hour" "$fixed_minute" "$([ $first -eq 1 ] && echo 0 || echo 1)")
+        first=0
+        log_message "下次簽到在 ${fixed_hour}:$(printf '%02d' "$fixed_minute")（約 ${delay} 秒後）"
+        sleep_seconds "$delay"
+        run_ptt_login true
+    done
+}
+
+# 生產模式：每日隨機時間，每次執行後重新抽時間並通知。
+run_random_daily_schedule() {
+    log_message "生產模式（每日隨機時間）：容器將持續運行"
+
+    local first=1 delay
+    while true; do
+        generate_random_time
+        notify_schedule_update "$RANDOM_HOUR" "$RANDOM_MINUTE"
+        # 首次依今天/明天最近一次排程；之後一律排到隔天，確保每天僅一次。
+        delay=$(seconds_until "$RANDOM_HOUR" "$RANDOM_MINUTE" "$([ $first -eq 1 ] && echo 0 || echo 1)")
+        first=0
+        log_message "下次簽到在 ${RANDOM_HOUR}:$(printf '%02d' "$RANDOM_MINUTE")（約 ${delay} 秒後）"
+        sleep_seconds "$delay"
+        run_ptt_login true
+    done
+}
+
+# 排程分派
+run_scheduler() {
     if [ "$TEST_MODE" = "true" ]; then
-        log_message "測試模式：容器將使用 cron 執行 3 次測試後自動停止"
-    else
-        if [ "$RANDOM_DAILY_TIME" = "true" ]; then
-            log_message "生產模式：容器將持續運行，每天使用不同的隨機時間執行簽到"
-        else
-            log_message "生產模式：容器將持續運行，每天固定時間執行簽到"
-        fi
-    fi
-    
-    # 環境檢查
-    if [ ! -f "/.dockerenv" ] && [ ! -d "/app" ]; then
-        log_message "不在 Docker 容器內，即將退出"
+        run_test_schedule
         return 0
     fi
-    
-    # 保持容器運行
-    log_message "容器監控已啟動，按 Ctrl+C 可停止容器"
-    while true; do
-        sleep 60
-    done
+
+    if [ "$RANDOM_DAILY_TIME" = "true" ]; then
+        run_random_daily_schedule
+    else
+        run_fixed_schedule
+    fi
 }
 
 # =============================================================================
@@ -428,6 +313,7 @@ show_usage() {
     echo "用法: $0 [選項]"
     echo ""
     echo "選項:"
+    echo "  --run-ptt-login  立即執行一次簽到（供 docker exec 手動觸發）"
     echo "  -h, --help       顯示此幫助信息"
     echo ""
     echo "環境變數:"
@@ -443,15 +329,6 @@ show_usage() {
 
 # 處理命令行參數
 process_args() {
-    # 顯示環境配置（調試模式）
-    if [ "$DEBUG_MODE" = "true" ]; then
-        log_debug "環境配置詳情:"
-        log_debug "- TEST_MODE=$TEST_MODE"
-        log_debug "- DEBUG_MODE=$DEBUG_MODE"
-        log_debug "- RANDOM_DAILY_TIME=$RANDOM_DAILY_TIME"
-    fi
-    
-    # 處理輸入參數
     while [[ $# -gt 0 ]]; do
         case $1 in
             --run-ptt-login)
@@ -478,7 +355,10 @@ process_args() {
 main() {
     # 處理命令行參數
     process_args "$@"
-    
+
+    # 收到停止訊號時乾淨退出（docker stop 送 SIGTERM 給 PID1）。
+    trap 'log_message "收到停止訊號，正在結束容器..."; exit 0' TERM INT
+
     # 顯示啟動標誌和設定
     log_message "====================================="
     log_message "      PTT 自動簽到 Docker 容器       "
@@ -487,35 +367,23 @@ main() {
     log_message "運行模式: $([ "$TEST_MODE" = "true" ] && echo "測試模式" || echo "生產模式")"
     log_message "調試模式: $([ "$DEBUG_MODE" = "true" ] && echo "開啟" || echo "關閉")"
     log_message "每日隨機時間: $([ "$RANDOM_DAILY_TIME" = "true" ] && echo "啟用" || echo "停用")"
-    
-    # 記錄環境變數詳情（調試模式）
-    log_debug "環境變數詳細設置:"
-    log_debug "- TEST_MODE=$TEST_MODE"
-    log_debug "- DEBUG_MODE=$DEBUG_MODE"
-    log_debug "- RANDOM_DAILY_TIME=$RANDOM_DAILY_TIME"
-    
+
     # 檢查環境變數
     if ! check_environment; then
         log_message "環境檢查失敗，程式即將退出"
         exit 1
     fi
-    
+
     # 驗證 PTT 憑證
     log_message "正在驗證 PTT 登入憑證..."
     if ! verify_credentials; then
         log_message "憑證驗證失敗，程式即將退出"
         exit 1
     fi
-    
-    # 設置 cron 任務
-    if ! setup_cron_job; then
-        log_message "cron 任務設置失敗，程式即將退出"
-        exit 1
-    fi
-    
-    # 監控容器
-    monitor_container
+
+    # 進入排程器（依模式持續運行或在測試完成後結束）
+    run_scheduler
 }
 
 # 執行主函數，傳遞所有命令行參數
-main "$@" 
+main "$@"


### PR DESCRIPTION
## 背景

兩個問題觸發本次重構：

1. **容器啟動 `exec /app/scripts/docker_runner.sh: exec format error`** — 在 Apple Silicon (arm64) build 出 image，跑在 amd64 主機（Synology DS923+）→ 架構不符。
2. **image ~200MB+ 過肥** — `python:3.11-slim` + Debian cron 一整套。

## 變更

### Image 瘦身（~200MB → ~100MB）
- base：`python:3.11-slim` → `python:3.11-alpine`
- 移除 `cron`/`curl`/`rsyslog`/`procps`；runtime 只留 `bash` + `tzdata` + `ca-certificates`
- builder 安裝到獨立 `/install` prefix 後整包複製（取代 editable install + 另外 copy src）

### 排程：cron → 內建 sleep loop（`scripts/docker_runner.sh`）
- 砍掉整套系統 cron（`setup_cron_job` / `update_cron_time` / 執行期產生的 `cron_wrapper.sh`、`daily_time_updater.sh` / `.cron_env`）
- 改用 `seconds_until()` 計算到下一個 HH:MM 的秒數（只用 `date +%H/%M/%S`，busybox 相容；Asia/Taipei 無 DST，一天固定 86400s）
- **行為保留**：測試模式每分鐘 ×3 後結束、生產每日 9–17 隨機時間、固定時間模式、Telegram 排程更新通知、簽到結果通知
- 輸出改落在 PID1 stdout/stderr → `docker logs` 直接可見；新增 SIGTERM/SIGINT trap 讓 `docker stop` 乾淨退出
- secrets 只存在 PID1 process env，`.cron_env` 硬化不再需要

### 文件
- README（中英）build 指令加上 `--platform linux/amd64`，避免在 arm64 機器 build 給 amd64 主機跑時 `exec format error`

## 行為微調（需留意）
- 排程更新通知時機：原本午夜重抽並通知 → 改為「每次簽到後重抽下一天時間並通知」（仍每天一則）
- 不再有 cron 包裝腳本藏密，secrets 走 docker `-e`（標準做法）

## 測試
- ✅ `bash -n` 語法檢查通過
- ✅ `seconds_until` 時間計算邏輯本機實測正確
- ✅ 既有 80 個 Python 測試全過（未動 Python）
- ⚠️ **未做 docker build/run 實測**（開發機 Docker daemon 未啟動）

### Test plan
- [ ] `docker build --platform linux/amd64 -t pttautosign-dev .` 成功且無缺套件
- [ ] `docker images` 確認大小 ~100MB
- [ ] `docker run --rm -e TEST_MODE=true -e DEBUG_MODE=true -e PTT_USERNAME=... -e PTT_PASSWORD=... -e TELEGRAM_BOT_TOKEN=... -e TELEGRAM_CHAT_ID=... pttautosign-dev` → 驗證憑證 → 每分鐘簽到 ×3 → 容器自動結束
- [ ] 生產模式啟動後確認 `docker logs` 顯示「下次簽到在 HH:MM」且 Telegram 收到排程通知